### PR TITLE
fix: security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV JSON_RPC_SERVER_BRANCH=${JSON_RPC_SERVER_BRANCH}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Create non-root user and set up directories
-RUN groupadd -r shardeum && useradd -r -g shardeum -m -s /bin/bash shardeum && \
+RUN groupadd -r shardeum && useradd -r -g shardeum -m shardeum && \
     mkdir -p /home/shardeum/.npm-global && \
     chown -R shardeum:shardeum /home/shardeum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.1
+FROM node:18.19.1-slim
 
 # Define build arguments for repository branches
 ARG SHARDEUM_BRANCH=dev
@@ -11,40 +11,54 @@ ENV RELAYER_COLLECTOR_BRANCH=${RELAYER_COLLECTOR_BRANCH}
 ENV JSON_RPC_SERVER_BRANCH=${JSON_RPC_SERVER_BRANCH}
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install jq
-RUN apt-get update && apt-get install -y jq
+# Create non-root user and set up directories
+RUN groupadd -r shardeum && useradd -r -g shardeum -m -s /bin/bash shardeum && \
+    mkdir -p /home/shardeum/.npm-global && \
+    chown -R shardeum:shardeum /home/shardeum
 
-# Install PM2 globally
+# Set npm to use user-specific global directory
+ENV NPM_CONFIG_PREFIX=/home/shardeum/.npm-global
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y jq \
+    build-essential \
+    curl \
+    git \
+    python3
+
+# Switch to non-root user for npm global install
+USER shardeum
+WORKDIR /home/shardeum
+
+ENV PATH="/home/shardeum/.npm-global/bin:/home/shardeum/.cargo/bin:${PATH}"
+
+# Install global npm packages
 RUN npm install -g pm2
 
 # Copy and run install script
 COPY scripts/install.sh .
-RUN chmod +x install.sh && ./install.sh
+RUN ./install.sh
 
-WORKDIR /app
-
-# Validator
-RUN git clone -b ${SHARDEUM_BRANCH} https://github.com/shardeum/shardeum 
+# Clone and install repositories as non-root user with shallow clones
+RUN git clone --depth 1 -b ${SHARDEUM_BRANCH} https://github.com/shardeum/shardeum
 RUN cd shardeum && npm ci
-RUN git clone -b ${RELAYER_COLLECTOR_BRANCH} https://github.com/shardeum/relayer-collector/
+RUN git clone --depth 1 -b ${RELAYER_COLLECTOR_BRANCH} https://github.com/shardeum/relayer-collector/
 RUN cd relayer-collector && npm install
-RUN git clone -b ${JSON_RPC_SERVER_BRANCH} https://github.com/shardeum/json-rpc-server
+RUN git clone --depth 1 -b ${JSON_RPC_SERVER_BRANCH} https://github.com/shardeum/json-rpc-server
 RUN cd json-rpc-server && npm install
 
-# Create required directories and database file with proper permissions
-RUN mkdir -p /app/shardeum/db && \
-    chmod -R 755 /app/shardeum/db
+# Create required directories with proper ownership
+RUN mkdir -p shardeum/db && \
+    chmod 750 shardeum/db
 
 # Copy ecosystem config
-COPY ecosystem.config.js /app/
+COPY ecosystem.config.js /home/shardeum/
 
 # Expose ports
 EXPOSE 8080 9001 10001 4000 6100 4446 6101
 
 # Configure services at runtime using environment variables
-COPY scripts/configure-and-start.sh /app/
-RUN chmod +x /app/configure-and-start.sh
+COPY scripts/configure-and-start.sh /home/shardeum/
 
-CMD ["/app/configure-and-start.sh"] 
+CMD ["/home/shardeum/configure-and-start.sh"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ You will need to have an archiver and distributor running somewhere. These confi
 docker pull ghcr.io/shardeum/ldrpc-docker
 
 docker run -p 8080:8080 -it \
-  -v shardeum_db:/app/shardeum/db \
-  -v relayer_collector_db:/app/relayer-collector/db \
+  -v shardeum_db:/home/shardeum/shardeum/db \
+  -v relayer_collector_db:/home/shardeum/relayer-collector/db \
   -e ARCHIVER_IP=<archiver-ip> \
   -e ARCHIVER_PORT=<archiver-port> \
   -e ARCHIVER_PUBKEY=<archiver-pubkey> \
@@ -79,8 +79,8 @@ The configuration is done through environment variables when running the contain
 
 If you want to persist the data between runs, you can mount volumes for the database directories:
 ```
-  -v shardeum_db:/app/shardeum/db \
-  -v relayer_collector_db:/app/relayer-collector/db \
+  -v shardeum_db:/home/shardeum/shardeum/db \
+  -v relayer_collector_db:/home/shardeum/relayer-collector/db \
 ```
 
 ## Keys

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,31 +2,31 @@ module.exports = {
   apps: [
     {
       name: 'validator',
-      cwd: '/app/shardeum',
+      cwd: '/home/shardeum/shardeum',
       script: 'dist/src/index.js',
       node_args: '--max_old_space_size=16000'
     },
     {
       name: 'collector-server',
-      cwd: '/app/relayer-collector',
+      cwd: '/home/shardeum/relayer-collector',
       script: 'dist/src/collector.js',
       node_args: '--max_old_space_size=16000'
     },
     {
       name: 'collector-api-server',
-      cwd: '/app/relayer-collector',
+      cwd: '/home/shardeum/relayer-collector',
       script: 'dist/src/server.js',
       node_args: '--max_old_space_size=16000'
     },
     {
       name: 'collector-log-server',
-      cwd: '/app/relayer-collector',
+      cwd: '/home/shardeum/relayer-collector',
       script: 'dist/src/log_server.js',
       node_args: '--max_old_space_size=16000'
     },
     {
       name: 'json-rpc-server',
-      cwd: '/app/json-rpc-server',
+      cwd: '/home/shardeum/json-rpc-server',
       script: 'npm',
       args: 'start',
       node_args: '--max_old_space_size=16000'

--- a/scripts/configure-and-start.sh
+++ b/scripts/configure-and-start.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+# Check for required environment variables
+required_vars=(
+  ARCHIVER_IP
+  ARCHIVER_PORT
+  ARCHIVER_PUBKEY
+  DISTRIBUTOR_IP
+  DISTRIBUTOR_PUBKEY
+  COLLECTOR_PUBKEY
+  COLLECTOR_SECRETKEY
+  COLLECTOR_MODE
+)
+
+missing_vars=()
+for var in "${required_vars[@]}"; do
+  if [ -z "${!var}" ]; then
+    missing_vars+=("$var")
+  fi
+done
+
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "ERROR: Missing required environment variables:"
+  printf '%s\n' "${missing_vars[@]}"
+  exit 1
+fi
+
 # Configure Service validator
 cd /home/shardeum/shardeum
 jq ".server.p2p.existingArchivers[].ip |= \"$ARCHIVER_IP\"" config.json > tmp.json && mv tmp.json config.json

--- a/scripts/configure-and-start.sh
+++ b/scripts/configure-and-start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cd /app/shardeum
+# Configure Service validator
+cd /home/shardeum/shardeum
 jq ".server.p2p.existingArchivers[].ip |= \"$ARCHIVER_IP\"" config.json > tmp.json && mv tmp.json config.json
 jq ".server.p2p.existingArchivers[].port |= \"$ARCHIVER_PORT\"" config.json > tmp.json && mv tmp.json config.json
 jq ".server.p2p.existingArchivers[].publicKey |= \"$ARCHIVER_PUBKEY\"" config.json > tmp.json && mv tmp.json config.json
@@ -8,7 +9,7 @@ sed -i "s/startInServiceMode: false/startInServiceMode: true/" src/shardeum/shar
 npm run prepare
 
 # Configure Relayer Collector
-cd /app/relayer-collector
+cd /home/shardeum/relayer-collector
 jq --arg ip "$DISTRIBUTOR_IP" \
    --arg dkey "$DISTRIBUTOR_PUBKEY" \
    --arg ckey "$COLLECTOR_PUBKEY" \
@@ -17,13 +18,13 @@ jq --arg ip "$DISTRIBUTOR_IP" \
    '.distributorInfo.ip |= $ip | .distributorInfo.publicKey |= $dkey | .collectorInfo.publicKey |= $ckey | .collectorInfo.secretKey |= $skey | .dataLogWrite = ($mode != "MQ")' \
    config.json > temp.json && mv temp.json config.json
 
-export SERVICE_VALIDATOR_DB_PATH=/app/shardeum/db/shardeum.sqlite
+export SERVICE_VALIDATOR_DB_PATH=/home/shardeum/shardeum/db/shardeum.sqlite
 mkdir -p db
-export COLLECTOR_DB_PATH=/app/relayer-collector/db/db.sqlite3
+export COLLECTOR_DB_PATH=/home/shardeum/relayer-collector/db/db.sqlite3
 npm run prepare
 
 # Configure JSON RPC Server
-cd /app/json-rpc-server
+cd /home/shardeum/json-rpc-server
 jq --arg ip "$ARCHIVER_IP" --arg key "$ARCHIVER_PUBKEY" \
    '.archivers[].ip |= $ip | .archivers[].publicKey |= $key' \
    archiverConfig.json > tmp.json && mv tmp.json archiverConfig.json
@@ -34,4 +35,4 @@ sed -i "s/serveSubscriptions: Boolean(process.env.WS_SAVE_SUBSCRIPTIONS) || fals
 npm run compile
 
 # Start services
-cd /app && pm2 start ecosystem.config.js && pm2 logs 
+cd /home/shardeum && pm2 start ecosystem.config.js && pm2 logs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Install system dependencies
-apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    python3 \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install Rust 1.74.1
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.74.1
 source $HOME/.cargo/env


### PR DESCRIPTION
Addresses the security review comments in this linear ticket:


https://linear.app/shm/issue/SHARD-1415/dockerize-ld-rpc

> The Dockerfile runs everything as root by default
- only `apt-get install` is run by root now

> The PATH modification is done for root user
- this is done for the `shardeum` user now

> Applications are installed in root-owned directories
- now writes to `/home/shardeum/`
    
> Global npm install as root
- using local dir now for global npm installs
```
shardeum@d1194a8b9749:~/app$ which pm2
/home/shardeum/.npm-global/bin/pm2
```

> No specific commit hashes used 
- not addressed in this PR, the use case here is mostly building release branches so it will have some sort of version in it like `itn4-1.16.3`
    
> Why default permission 755, not 750?
- fixed

> Will it work with slim image?
- fixed
