### PR TITLE
fix: add RATE_LIMIT=false in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ docker run -p 8080:8080 -p 9001:9001 -p 10001:10001 -p 4000:4000 -p 6100:6100 -p
   -e RMQ_CYCLES_QUEUE_NAME=<rmq-cycles-queue-name> \
   -e RMQ_RECEIPTS_QUEUE_NAME=<rmq-receipts-queue-name> \
   -e RMQ_ORIGINAL_TXS_QUEUE_NAME=<rmq-original-txs-queue-name> \
+  -e RATE_LIMIT=false \
   ghcr.io/shardeum/ldrpc-docker
 ```
 


### PR DESCRIPTION
I was able to reproduce an issue an exchange had with our rate limiting. If you end up hitting the rate limit by calling [`eth_sendRawTransaction`](https://github.com/shardeum/json-rpc-server/blob/1d18451c97bf04120fb9d06d22902f3f2bf9ec90/src/middlewares/rateLimit/RequestersList.ts#L332) enough times you will end up not being able to call a read-only method like `eth_gasPrice` which I'm not sure is intended.

This PR adds sets it to false in the README example.