### PR TITLE
fix: remove latest from build trigger

### DIFF
--- a/.github/workflows/trigger_build_push.yml
+++ b/.github/workflows/trigger_build_push.yml
@@ -22,11 +22,6 @@ on:
       image_tag:
         description: 'Docker image tag (will be combined with network name)'
         required: true
-      push_latest:
-        description: 'Push latest tag'
-        type: boolean
-        required: true
-        default: false
       network:
         type: choice
         description: 'Network. Will use the config for the network in scripts/config if it exists. Custom if you are doing a custom build and will use environment variables passed to Docker run.'
@@ -101,11 +96,6 @@ jobs:
       - name: Push Docker image and cleanup
         run: |
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:${{ steps.build_config.outputs.IMAGE_TAG }}
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.push_latest }}" == "true" ]; then
-            docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:${{ steps.build_config.outputs.IMAGE_TAG }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:latest
-            docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:latest
-            docker rmi ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:latest
-          fi
           # Remove the image after pushing
           docker rmi ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:${{ steps.build_config.outputs.IMAGE_TAG }}
 
@@ -140,13 +130,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-amd64:${{ steps.build_config.outputs.IMAGE_TAG }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:${{ steps.build_config.outputs.IMAGE_TAG }}
           docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.build_config.outputs.IMAGE_TAG }}
-          
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.push_latest }}" == "true" ]; then
-            docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-amd64:latest \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest
-            docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          fi
 
   slack-notify:
     needs: create-manifest


### PR DESCRIPTION
Ideally we should be using the promote-latest.yml workflow we have now that is locked down to certain environments.